### PR TITLE
Switch to https for remote github repository

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
           recurse=yes state=directory
 
   - name: Fetch SickBeard from GitHub
-    git: repo=git://github.com/midgetspy/Sick-Beard
+    git: repo=https://github.com/midgetspy/Sick-Beard
          dest={{ sickbeard_binary_path }}
          update=no
 


### PR DESCRIPTION
We don't have our SSH public key from GitHub on the remote server so it isn't possible to clone the remote repository by ssh+git. I've switched to HTTPS which should work anyway.
